### PR TITLE
License headers changed in hoogdalem project to standard USEF license

### DIFF
--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/devicemessages/ReservedDevice.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/devicemessages/ReservedDevice.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.devicemessages;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/devicemessages/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/devicemessages/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 /**
  * contains classes related to usef device messages

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/dtos/ForecastType.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/dtos/ForecastType.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.agr.dtos;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/dtos/Proposition.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/dtos/Proposition.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.agr.dtos;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/dtos/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/dtos/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 /**
  * contains classes related to forecasts in pbcs

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/AgrInitiateSettlement.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/AgrInitiateSettlement.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/AgrValidateSettlementItems.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/AgrValidateSettlementItems.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/ControlActiveDemandSupply.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/ControlActiveDemandSupply.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/CreateConnectionProfile.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/CreateConnectionProfile.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.agr.pbc;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/CreateNDayAheadForecast.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/CreateNDayAheadForecast.java
@@ -1,21 +1,17 @@
 /*
- * This software source code is provided by the USEF Foundation. The copyright
- * and all other intellectual property rights relating to all software source
- * code provided by the USEF Foundation (and changes and modifications as well
- * as on new versions of this software source code) belong exclusively to the
- * USEF Foundation and/or its suppliers or licensors. Total or partial
- * transfer of such a right is not allowed. The user of the software source
- * code made available by USEF Foundation acknowledges these rights and will
- * refrain from any form of infringement of these rights.
+ * Copyright 2015-2016 USEF Foundation
  *
- * The USEF Foundation provides this software source code "as is". In no event
- * shall the USEF Foundation and/or its suppliers or licensors have any
- * liability for any incidental, special, indirect or consequential damages;
- * loss of profits, revenue or data; business interruption or cost of cover or
- * damages arising out of or in connection with the software source code or
- * accompanying documentation.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * For the full license agreement see http://www.usef.info/license.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/CreateUdi.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/CreateUdi.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/DetectDeviationFromPrognoses.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/DetectDeviationFromPrognoses.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/DetermineNetDemands.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/DetermineNetDemands.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/FlexOfferDetermineFlexibility.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/FlexOfferDetermineFlexibility.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/IdentifyChangeInForecast.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/IdentifyChangeInForecast.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/ReCreatePrognoses.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/ReCreatePrognoses.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/ReOptimizePortfolio.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/ReOptimizePortfolio.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/ReOptimizePortfolioEmpty.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/ReOptimizePortfolioEmpty.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/UpdateElementDataStore.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/UpdateElementDataStore.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.agr.pbc;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/pbc/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/udis/Counter.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/udis/Counter.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.udis;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/udis/UdiConfiguration.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/udis/UdiConfiguration.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.udis;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/udis/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/agr/udis/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/configurationservice/AgrConfiguration.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/configurationservice/AgrConfiguration.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.configurationservice;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/configurationservice/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/configurationservice/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/ConnectionManager.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/ConnectionManager.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.forecastservice;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/ForecastService.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/ForecastService.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.forecastservice;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/element/DefaultElement.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/element/DefaultElement.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.forecastservice.element;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/element/ElementType.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/element/ElementType.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.forecastservice.element;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/element/ElementsFactory.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/element/ElementsFactory.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.forecastservice.element;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/element/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/element/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/forecast/DefaultForecast.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/forecast/DefaultForecast.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.forecastservice.forecast;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/forecast/ForecastFactory.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/forecast/ForecastFactory.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.forecastservice.forecast;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/forecast/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/forecast/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/weather/HourlyForecast.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/weather/HourlyForecast.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.forecastservice.weather;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/weather/WeatherService.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/weather/WeatherService.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.forecastservice.weather;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/weather/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/forecastservice/weather/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/MessageScheduler.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/MessageScheduler.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.messageservice.scheduleservice;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/PrepareEvent.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/PrepareEvent.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.messageservice.scheduleservice.tasks;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/PrepareTask.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/PrepareTask.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.messageservice.scheduleservice.tasks;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/ShiftEvent.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/ShiftEvent.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.messageservice.scheduleservice.tasks;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/ShiftTask.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/ShiftTask.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.messageservice.scheduleservice.tasks;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/TimeEvent.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/TimeEvent.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.messageservice.scheduleservice.tasks;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**contains classes related to events | tasks for device messages */

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/MessageCallback.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/MessageCallback.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.messageservice.transportservice;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/MqttConnection.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/MqttConnection.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.messageservice.transportservice;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/data/ActualDeviceData.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/data/ActualDeviceData.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.messageservice.transportservice.data;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/data/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/data/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/mqttmessages/MqttResponseMessage.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/mqttmessages/MqttResponseMessage.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.messageservice.transportservice.mqttmessages;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/mqttmessages/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/mqttmessages/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/messageservice/transportservice/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/util/EANUtil.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/util/EANUtil.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.util;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/util/PortfolioUtil.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/util/PortfolioUtil.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.util;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/util/ReserveDeviceUtil.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/util/ReserveDeviceUtil.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.util;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/util/TimeUtil.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/util/TimeUtil.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.util;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/util/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/main/java/nl/energieprojecthoogdalem/util/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/dtos/PropositionTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/dtos/PropositionTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.agr.dtos;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/AgrInitiateSettlementTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/AgrInitiateSettlementTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/AgrValidateSettlementItemsTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/AgrValidateSettlementItemsTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/ControlActiveDemandSupplyTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/ControlActiveDemandSupplyTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.agr.pbc;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/CreateConnectionProfileTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/CreateConnectionProfileTest.java
@@ -1,21 +1,17 @@
 /*
- * This software source code is provided by the USEF Foundation. The copyright
- * and all other intellectual property rights relating to all software source
- * code provided by the USEF Foundation (and changes and modifications as well
- * as on new versions of this software source code) belong exclusively to the
- * USEF Foundation and/or its suppliers or licensors. Total or partial
- * transfer of such a right is not allowed. The user of the software source
- * code made available by USEF Foundation acknowledges these rights and will
- * refrain from any form of infringement of these rights.
+ * Copyright 2015-2016 USEF Foundation
  *
- * The USEF Foundation provides this software source code "as is". In no event
- * shall the USEF Foundation and/or its suppliers or licensors have any
- * liability for any incidental, special, indirect or consequential damages;
- * loss of profits, revenue or data; business interruption or cost of cover or
- * damages arising out of or in connection with the software source code or
- * accompanying documentation.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * For the full license agreement see http://www.usef.info/license.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/CreateNDayAheadForecastTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/CreateNDayAheadForecastTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/CreateUdiTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/CreateUdiTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/DetectDeviationFromPrognosesTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/DetectDeviationFromPrognosesTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/DetermineNetDemandsTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/DetermineNetDemandsTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/FlexOfferDetermineFlexibilityTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/FlexOfferDetermineFlexibilityTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/IdentifyChangeInForecastTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/IdentifyChangeInForecastTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.agr.pbc;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/ReCreatePrognosesTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/ReCreatePrognosesTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/ReOptimizePortfolioEmptyTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/ReOptimizePortfolioEmptyTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/ReOptimizePortfolioTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/ReOptimizePortfolioTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/RealMessageTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/RealMessageTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.agr.pbc;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/UpdateElementDataStoreTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/pbc/UpdateElementDataStoreTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/udis/CounterTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/udis/CounterTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.udis;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/udis/UdiConfigurationTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/agr/udis/UdiConfigurationTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.agr.udis;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/configurationservice/AgrConfigurationTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/configurationservice/AgrConfigurationTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.configurationservice;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/ConnectionManagerTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/ConnectionManagerTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.forecastservice;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/ForecastServiceTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/ForecastServiceTest.java
@@ -1,11 +1,17 @@
-/**
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+/*
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.forecastservice;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/RealDatabaseConnectionTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/RealDatabaseConnectionTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.forecastservice;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/element/ElementsFactoryTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/element/ElementsFactoryTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.forecastservice.element;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/forecast/DefaultForecastTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/forecast/DefaultForecastTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.forecastservice.forecast;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/forecast/ForecastFactoryTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/forecast/ForecastFactoryTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.forecastservice.forecast;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/weather/HourlyForecastTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/weather/HourlyForecastTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.forecastservice.weather;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/weather/WeatherServiceTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/forecastservice/weather/WeatherServiceTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.forecastservice.weather;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/MessageSchedulerTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/MessageSchedulerTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.messageservice.scheduleservice;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/TimeEventTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/scheduleservice/tasks/TimeEventTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.messageservice.scheduleservice.tasks;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/transportservice/MessageCallbackTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/transportservice/MessageCallbackTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.messageservice.transportservice;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/transportservice/MqttConnectionTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/transportservice/MqttConnectionTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.messageservice.transportservice;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/transportservice/RealMqttConnectionTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/transportservice/RealMqttConnectionTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.messageservice.transportservice;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/transportservice/data/ActualDeviceDataTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/transportservice/data/ActualDeviceDataTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.messageservice.transportservice.data;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/transportservice/mqttmessages/MqttResponseMessageTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/messageservice/transportservice/mqttmessages/MqttResponseMessageTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.messageservice.transportservice.mqttmessages;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/util/EANUtilTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/util/EANUtilTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.util;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/util/PortfolioUtilTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/util/PortfolioUtilTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.util;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/util/ReserveDeviceUtilTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/util/ReserveDeviceUtilTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.util;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/util/TimeUtilTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-agr1/src/test/java/nl/energieprojecthoogdalem/util/TimeUtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015-2016 USEF Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package nl.energieprojecthoogdalem.util;
 
 import org.joda.time.LocalDateTime;
@@ -5,15 +21,6 @@ import org.joda.time.LocalTime;
 import org.junit.Assert;
 import org.junit.Test;
 
-/*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
- *
- * Software is subject to the following conditions:
- *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
 public class TimeUtilTest {
 
     private static int ptuDuration = 15;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-brp/src/main/java/nl/energieprojecthoogdalem/brp/ReceivedAPlan.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-brp/src/main/java/nl/energieprojecthoogdalem/brp/ReceivedAPlan.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.brp;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-brp/src/main/java/nl/energieprojecthoogdalem/brp/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-brp/src/main/java/nl/energieprojecthoogdalem/brp/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-brp/src/test/java/nl/energieprojecthoogdalem/brp/ReceivedAPlanTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-brp/src/test/java/nl/energieprojecthoogdalem/brp/ReceivedAPlanTest.java
@@ -1,21 +1,17 @@
 /*
- * This software source code is provided by the USEF Foundation. The copyright
- * and all other intellectual property rights relating to all software source
- * code provided by the USEF Foundation (and changes and modifications as well
- * as on new versions of this software source code) belong exclusively to the
- * USEF Foundation and/or its suppliers or licensors. Total or partial
- * transfer of such a right is not allowed. The user of the software source
- * code made available by USEF Foundation acknowledges these rights and will
- * refrain from any form of infringement of these rights.
+ * Copyright 2015-2016 USEF Foundation
  *
- * The USEF Foundation provides this software source code "as is". In no event
- * shall the USEF Foundation and/or its suppliers or licensors have any
- * liability for any incidental, special, indirect or consequential damages;
- * loss of profits, revenue or data; business interruption or cost of cover or
- * damages arising out of or in connection with the software source code or
- * accompanying documentation.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * For the full license agreement see http://www.usef.info/license.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.brp;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/limits/ConnectionManager.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/limits/ConnectionManager.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nl.energieprojecthoogdalem.dso.limits;
 

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/limits/LimitConfiguration.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/limits/LimitConfiguration.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.limits;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/limits/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/limits/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/CreateFlexRequest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/CreateFlexRequest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/CreateGridSafetyAnalysis.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/CreateGridSafetyAnalysis.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/CreateMissingDPrognoses.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/CreateMissingDPrognoses.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/CreateNonAggregatorForecast.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/CreateNonAggregatorForecast.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/DsoInitiateSettlement.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/DsoInitiateSettlement.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/DsoMonitorGrid.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/DsoMonitorGrid.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/DsoRequestPenaltyData.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/DsoRequestPenaltyData.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/PlaceFlexOrders.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/PlaceFlexOrders.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/main/java/nl/energieprojecthoogdalem/dso/pbc/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/limits/ConnectionManagerTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/limits/ConnectionManagerTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.limits;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/limits/LimitConfigurationTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/limits/LimitConfigurationTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.limits;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/CreateFlexRequestTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/CreateFlexRequestTest.java
@@ -1,21 +1,17 @@
 /*
- * This software source code is provided by the USEF Foundation. The copyright
- * and all other intellectual property rights relating to all software source
- * code provided by the USEF Foundation (and changes and modifications as well
- * as on new versions of this software source code) belong exclusively to the
- * USEF Foundation and/or its suppliers or licensors. Total or partial
- * transfer of such a right is not allowed. The user of the software source
- * code made available by USEF Foundation acknowledges these rights and will
- * refrain from any form of infringement of these rights.
+ * Copyright 2015-2016 USEF Foundation
  *
- * The USEF Foundation provides this software source code "as is". In no event
- * shall the USEF Foundation and/or its suppliers or licensors have any
- * liability for any incidental, special, indirect or consequential damages;
- * loss of profits, revenue or data; business interruption or cost of cover or
- * damages arising out of or in connection with the software source code or
- * accompanying documentation.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * For the full license agreement see http://www.usef.info/license.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/CreateGridSafetyAnalysisTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/CreateGridSafetyAnalysisTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/CreateMissingDPrognosesTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/CreateMissingDPrognosesTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/CreateNonAggregatorForecastTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/CreateNonAggregatorForecastTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015-2016 USEF Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
 package nl.energieprojecthoogdalem.dso.pbc;
 
 import info.usef.core.util.DateTimeUtil;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/DsoInitiateSettlementTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/DsoInitiateSettlementTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/DsoMonitorGridTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/DsoMonitorGridTest.java
@@ -1,21 +1,17 @@
 /*
- * This software source code is provided by the USEF Foundation. The copyright
- * and all other intellectual property rights relating to all software source
- * code provided by the USEF Foundation (and changes and modifications as well
- * as on new versions of this software source code) belong exclusively to the
- * USEF Foundation and/or its suppliers or licensors. Total or partial
- * transfer of such a right is not allowed. The user of the software source
- * code made available by USEF Foundation acknowledges these rights and will
- * refrain from any form of infringement of these rights.
+ * Copyright 2015-2016 USEF Foundation
  *
- * The USEF Foundation provides this software source code "as is". In no event
- * shall the USEF Foundation and/or its suppliers or licensors have any
- * liability for any incidental, special, indirect or consequential damages;
- * loss of profits, revenue or data; business interruption or cost of cover or
- * damages arising out of or in connection with the software source code or
- * accompanying documentation.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * For the full license agreement see http://www.usef.info/license.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/DsoRequestPenaltyDataTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/DsoRequestPenaltyDataTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/PlaceFlexOrdersTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-dso/src/test/java/nl/energieprojecthoogdalem/dso/pbc/PlaceFlexOrdersTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.dso.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-mdc/src/main/java/nl/energieprojecthoogdalem/mdc/pbc/MdcMeterDataQuery.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-mdc/src/main/java/nl/energieprojecthoogdalem/mdc/pbc/MdcMeterDataQuery.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.mdc.pbc;

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-mdc/src/main/java/nl/energieprojecthoogdalem/mdc/pbc/package-info.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-mdc/src/main/java/nl/energieprojecthoogdalem/mdc/pbc/package-info.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-mdc/src/test/java/nl/energieprojecthoogdalem/mdc/pbc/MdcMeterDataQueryTest.java
+++ b/usef-build/usef-hoogdalem/usef-workflow-hd/usef-hd-mdc/src/test/java/nl/energieprojecthoogdalem/mdc/pbc/MdcMeterDataQueryTest.java
@@ -1,11 +1,17 @@
 /*
- * Copyright (c) 2014-2016 BePowered BVBA http://www.bepowered.be/
+ * Copyright 2015-2016 USEF Foundation
  *
- * Software is subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice shall be included in all copies or substantial portions of the Software.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package nl.energieprojecthoogdalem.mdc.pbc;


### PR DESCRIPTION
suggestion to set all license headers in the Hoogdalum project to standard USEF license header format.
